### PR TITLE
Update details on Clearcase & RTC source control

### DIFF
--- a/version_control/README.md
+++ b/version_control/README.md
@@ -35,4 +35,8 @@ This repository documents the TRM-acknowledged VCS tools, and provides details o
 
 It summarizes this research into a [comparison](./comparison.md) document and a set of  [recommendations](./recommendations.md) for amending the TRM going forward.
 
-These conclusions were based on defined [criteria](./criteria.md) reviewing [historical performance](./historicial_context.md), developer tooling [support](./ide-support.md), [ease of migration](migration_details.md) (in support of future advancements), and integration with the [Open Source Software](./oss-integration.md) community and the suite of [Rational Team Concert](./rtc-integration.md)
+These conclusions were based on defined [criteria](./criteria.md):
+* reviewing [historical performance](./historicial_context.md)
+* developer tooling [support](./ide-support.md)
+* [ease of migration](migration_details.md) (in support of future advancements)
+* integration with the [Open Source Software](./oss-integration.md) community & the suite of [Rational Team Concert](./rtc-integration.md) tools

--- a/version_control/README.md
+++ b/version_control/README.md
@@ -1,0 +1,38 @@
+# VA Code Version Control Systems
+
+## Definition and justification
+Version Control Systems (VCS) allow you to manage the changes over time for a file or set of files, and supports operations to manage that change over time. They will also let you revert to a previous version of the file from a specific point in time. It also manages metadata about the files and revisions, including who is making the changes and when. You can use VCS along with other tools to enforce business rules (formatting, file contents, collision detection) to ensure the quality of the content.
+
+Using a modern version control tool can improve software quality and decrease risk.
+
+## TRM Products with VCS capability
+The VA Technical Reference Model (TRM) is a catalog of software products with associated recommendations.  These recommendations range include:
+* approved (unrestricted use)
+* approved with constraints (limited use)
+* deprecated / divest (time-limited use)
+* unapproved /  prohibited (no use permitted)
+
+The following is a list of products in the TRM which have some sort of code version-control system  (VCS) capability. Source code version control may be a core feature (Perforce, CVS, or Github and all Git-related technologies) or may be a non-core, plug-in feature which is replaceable with any other core VCS system (i.e. the Microsoft and IBM's project management tools have replaceable, plug-in VCS).
+
+| Manufacturer | Product | TRM Status |
+|:------- |:------- |:------:|:-------:|
+| OSS | Git Server | [Divest](http://www.va.gov/TRM/ToolPage.asp?tid=6396) |
+| GitHub | GitHub Enterprise | [Divest](http://www.va.gov/TRM/ToolPage.asp?tid=9533#) |
+| GitLab | GitLab CE | [Unapproved](http://www.va.gov/TRM/ToolPage.asp?tid=9580) |
+| GitLab | GitLab Enterprise | [Divest](http://www.va.gov/TRM/ToolPage.asp?tid=9463#) |
+| Apache | Subversion | [Prohibited](http://www.va.gov/TRM/ToolPage.asp?tid=6573) |
+| OSS | CVS | [Prohibited](http://www.va.gov/TRM/ToolPage.asp?tid=194) |
+| Perforce | Helix versioning engine | [Prohibited](http://www.va.gov/TRM/ToolPage.asp?tid=268) |  
+| IBM | Clear Case MultiSite | [Divest (Read-only)](http://www.va.gov/TRM/ToolPage.asp?tid=39#) |  
+| IBM | Rational Team Concert (RTC) | [Approved](http://www.va.gov/TRM/ToolPage.asp?tid=5085#) |
+| Serena | Dimensions CM | [Divest](http://www.va.gov/TRM/ToolPage.asp?tid=5136#) |
+| Endevor | Software Change Manager (SCM) | [Approved](http://www.va.gov/TRM/ToolPage.asp?tid=9481#) |  
+| Microsoft | Team Foundation Server (TFS) | [Approved](http://www.va.gov/TRM/ToolPage.asp?tid=5668#) |
+| Microsoft | Visual Source Safe (VSS) | [Prohibited](http://www.va.gov/TRM/ToolPage.asp?tid=5669) |
+
+## Comparing the various VCS
+This repository documents the TRM-acknowledged VCS tools, and provides details on their use and design.
+
+It summarizes this research into a [comparison](./comparison.md) document and a set of  [recommendations](./recommendations.md) for amending the TRM going forward.
+
+These conclusions were based on defined [criteria](./criteria.md) reviewing [historical performance](./historicial_context.md), developer tooling [support](./ide-support.md), [ease of migration](migration_details.md) (in support of future advancements), and integration with the [Open Source Software](./oss-integration.md) community and the suite of [Rational Team Concert](./rtc-integration.md)

--- a/version_control/README.md
+++ b/version_control/README.md
@@ -36,7 +36,7 @@ This repository documents the TRM-acknowledged VCS tools, and provides details o
 It summarizes this research into a [comparison](./comparison.md) document and a set of  [recommendations](./recommendations.md) for amending the TRM going forward.
 
 These conclusions were based on defined [criteria](./criteria.md):
-* reviewing [historical performance](./historicial_context.md)
+* reviewing [historical performance](./historical_context.md)
 * developer tooling [support](./ide-support.md)
 * [ease of migration](migration_details.md) (in support of future advancements)
 * integration with the [Open Source Software](./oss-integration.md) community & the suite of [Rational Team Concert](./rtc-integration.md) tools

--- a/version_control/historical_context.md
+++ b/version_control/historical_context.md
@@ -13,7 +13,7 @@ TRM defined VCS systems (chart as of 3-Aug-2016):
 | OSS | CVS | N | 08-05-2008 | N | [Wikipedia](https://en.wikipedia.org/wiki/Concurrent_Versions_System) |
 | Perforce | Helix versioning engine | Y | 19-May-2016 | Unknown | [Wikipedia](https://www.perforce.com/resources/software-release-index). Under new ownership, most staff has left |
 | IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
-| IBM | Rational Team Concert (RTC) | Y | 26-Jun-2015 | Y | Development no longer being done by IBM but instead Persistent Systems? |
+| IBM | Rational Team Concert (RTC) | Y | 26-Jun-2015 | Unknown | Development no longer being done by IBM but instead Persistent Systems? |
 | Serena | Dimensions CM | Y | 6-Jun-2014 | Unknown | Legacy-customer support |
 | Endevor | Software Change Manager (SCM) | Y | 21-Jun-2016 | Y | z/OS, mainframe only |
 | Microsoft | Team Foundation Server (TFS) | Y | 27-Jun-2016 | Y | Microsoft Language focused |

--- a/version_control/historical_context.md
+++ b/version_control/historical_context.md
@@ -12,7 +12,7 @@ TRM defined VCS systems (chart as of 3-Aug-2016):
 | Apache | Subversion | Y | 05-Aug-2015 | Y | |
 | OSS | CVS | N | 08-05-2008 | N | [Wikipedia](https://en.wikipedia.org/wiki/Concurrent_Versions_System) |
 | Perforce | Helix versioning engine | Y | 19-May-2016 | Unknown | [Wikipedia](https://www.perforce.com/resources/software-release-index). Under new ownership, most staff has left |
-| IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
+| IBM | ClearCase MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
 | IBM | Rational Team Concert (RTC) source control | Y | 26-Jun-2015 | Unknown | Development no longer being done by IBM but instead Persistent Systems? |
 | Serena | Dimensions CM | Y | 6-Jun-2014 | Unknown | Legacy-customer support |
 | Endevor | Software Change Manager (SCM) | Y | 21-Jun-2016 | Y | z/OS, mainframe only |

--- a/version_control/historical_context.md
+++ b/version_control/historical_context.md
@@ -12,8 +12,8 @@ TRM defined VCS systems (chart as of 3-Aug-2016):
 | Apache | Subversion | Y | 05-Aug-2015 | Y | |
 | OSS | CVS | N | 08-05-2008 | N | [Wikipedia](https://en.wikipedia.org/wiki/Concurrent_Versions_System) |
 | Perforce | Helix versioning engine | Y | 19-May-2016 | Unknown | [Wikipedia](https://www.perforce.com/resources/software-release-index). Under new ownership, most staff has left |
-| IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC |
-| IBM | Rational Team Concert (RTC) | Y | 26-Jun-2015 | Y | |
+| IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained or supported by IBM (now HCL) |
+| IBM | Rational Team Concert (RTC) | Y | 26-Jun-2015 | Y | Development no longer being done by IBM but instead Persistent Systems? |
 | Serena | Dimensions CM | Y | 6-Jun-2014 | Unknown | Legacy-customer support |
 | Endevor | Software Change Manager (SCM) | Y | 21-Jun-2016 | Y | z/OS, mainframe only |
 | Microsoft | Team Foundation Server (TFS) | Y | 27-Jun-2016 | Y | Microsoft Language focused |

--- a/version_control/historical_context.md
+++ b/version_control/historical_context.md
@@ -13,7 +13,7 @@ TRM defined VCS systems (chart as of 3-Aug-2016):
 | OSS | CVS | N | 08-05-2008 | N | [Wikipedia](https://en.wikipedia.org/wiki/Concurrent_Versions_System) |
 | Perforce | Helix versioning engine | Y | 19-May-2016 | Unknown | [Wikipedia](https://www.perforce.com/resources/software-release-index). Under new ownership, most staff has left |
 | IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
-| IBM | Rational Team Concert (RTC) | Y | 26-Jun-2015 | Unknown | Development no longer being done by IBM but instead Persistent Systems? |
+| IBM | Rational Team Concert (RTC) source control | Y | 26-Jun-2015 | Unknown | Development no longer being done by IBM but instead Persistent Systems? |
 | Serena | Dimensions CM | Y | 6-Jun-2014 | Unknown | Legacy-customer support |
 | Endevor | Software Change Manager (SCM) | Y | 21-Jun-2016 | Y | z/OS, mainframe only |
 | Microsoft | Team Foundation Server (TFS) | Y | 27-Jun-2016 | Y | Microsoft Language focused |

--- a/version_control/historical_context.md
+++ b/version_control/historical_context.md
@@ -12,7 +12,7 @@ TRM defined VCS systems (chart as of 3-Aug-2016):
 | Apache | Subversion | Y | 05-Aug-2015 | Y | |
 | OSS | CVS | N | 08-05-2008 | N | [Wikipedia](https://en.wikipedia.org/wiki/Concurrent_Versions_System) |
 | Perforce | Helix versioning engine | Y | 19-May-2016 | Unknown | [Wikipedia](https://www.perforce.com/resources/software-release-index). Under new ownership, most staff has left |
-| IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained or supported by IBM (now HCL) |
+| IBM | RTC Clear Case MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
 | IBM | Rational Team Concert (RTC) | Y | 26-Jun-2015 | Y | Development no longer being done by IBM but instead Persistent Systems? |
 | Serena | Dimensions CM | Y | 6-Jun-2014 | Unknown | Legacy-customer support |
 | Endevor | Software Change Manager (SCM) | Y | 21-Jun-2016 | Y | z/OS, mainframe only |

--- a/version_control/historical_context.md
+++ b/version_control/historical_context.md
@@ -12,8 +12,8 @@ TRM defined VCS systems (chart as of 3-Aug-2016):
 | Apache | Subversion | Y | 05-Aug-2015 | Y | |
 | OSS | CVS | N | 08-05-2008 | N | [Wikipedia](https://en.wikipedia.org/wiki/Concurrent_Versions_System) |
 | Perforce | Helix versioning engine | Y | 19-May-2016 | Unknown | [Wikipedia](https://www.perforce.com/resources/software-release-index). Under new ownership, most staff has left |
-| IBM | ClearCase MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
-| IBM | Rational Team Concert (RTC) source control | Y | 26-Jun-2015 | Unknown | Development no longer being done by IBM but instead Persistent Systems? |
+| IBM/HCL | ClearCase MultiSite | Y | 1-Mar-2016 | Unknown | Focus shifted towards RTC; No longer maintained by IBM (now HCL) |
+| IBM/PS | Rational Team Concert (RTC) source control | Y | 26-Jun-2015 | Unknown | Development no longer being done by IBM but instead Persistent Systems? |
 | Serena | Dimensions CM | Y | 6-Jun-2014 | Unknown | Legacy-customer support |
 | Endevor | Software Change Manager (SCM) | Y | 21-Jun-2016 | Y | z/OS, mainframe only |
 | Microsoft | Team Foundation Server (TFS) | Y | 27-Jun-2016 | Y | Microsoft Language focused |


### PR DESCRIPTION
IBM has recently announced that they have entered a partnership with HCL for the continued development and maintenance of IBM Clearcase: https://www.ibm.com/blogs/systems/partnership-growth-innovation/

However, despite the cheery words in the release, the Internet believes there could be a bit more to it: https://www.thelayoff.com/t/Ij76XnA

Relevant quotes:

> 75 employees will be transferred under HCL Technologies  

---

> This is not outsourcing. This is a complete divestment.

---

> To clarify, IBM has retained all IP and product direction for the Jazz platform products (RTC, etc) but development will be handled by Persistent Systems.
> 
> The Rational dev tools (ClearCase, ClearQuest) have been sold directly to HCL. IBM will not retain any ownership.

---

> From the wording, it sounds like IBM continues to hold and own the software titles themselves, continuing to market, sell and act as "owner", but is outsourcing all development and support to HCL. So HCL isn't buying anything, but IBM is reducing operational costs via HCL, letting HCL take the PR hit for making unpopular decisions down the line as cost compression measures are taken.
> 
> As an investor, this looks to me the IBM executive team is stripping these assets for the cash flow to divert to more imperative directions, and putting these products in the hands of an operator known for relentlessly driving down operational costs of support and development without incurring excessively high customer defection rates (at least initially for 3-5 years say) from the accompanying quality and market leadership drop. HCL is good at cost containment, but they aren't a development and support powerhouse consistently scoring in the Gartner top quadrant.
> 
> Can't imagine customers of any of these products happy or comfortable with this though, once word filters out to them about it. 
> (via [reddit](https://www.reddit.com/r/IBM/comments/4ur1bn/hcl_technologies_taking_over_support_and/))
